### PR TITLE
Copy change for mobile optimization

### DIFF
--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -12,7 +12,7 @@
       <div class="form-group"><label class="sr-hide" for="FULLNAME">Your name</label><input type="text" placeholder="Your Name" id="FULLNAME" name="FULLNAME" /></div>
       <div class="form-group"><label class="sr-hide" for="EMAIL">Your email address (required)</label><input type="email" placeholder="your@email-address.com" id="EMAIL" required name="EMAIL" /></div>
       <div style="position: absolute; left: -5000px;"><input type="hidden" name="b_6f1977de9eff4c384dc8d6527_cbc418738b" tabindex="-1" value=""></div>
-      <input type="submit" class="button" value="Sign up to subscribe to our newsletter" />
+      <input type="submit" class="button" value="Subscribe to our newsletter" />
       </form>
     </div>
     <div class="newsletter-words">


### PR DESCRIPTION
"Sign up to subscribe to our newsletter" is too long and spills over the button on mobile (320px). I think "Subscribe to our newsletter" adequately conveys the correct information to people, and also makes the button work for mobile. The alternative that I tried was reducing the font-size to 0.9em, but this is a better solution IMO.
